### PR TITLE
chore(deps): refresh node dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: 25.0.5(typescript@6.0.3)
       semantic-release-replace-plugin:
         specifier: github:centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin
-        version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/7a70d84bf39fe3f6366979540d7c186f8042dca8(typescript@6.0.3)
+        version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/d0080152603e574343e115e2eef9aac500a5597e(typescript@6.0.3)
       semantic-release-teams-notify-plugin:
         specifier: github:centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin
         version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin/tar.gz/50742ca66679b77a1275c23bc802cba3b72a9ba2
@@ -1566,8 +1566,8 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
-  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/7a70d84bf39fe3f6366979540d7c186f8042dca8:
-    resolution: {gitHosted: true, integrity: sha512-K/MZn7unuheYGVCk5ZYA18A/8GhQ1BU+AuFOaWSFBOFOIpZbkxs54TRgV6zdUQfmpws/UeWL9RWtpfh9s5UEng==, tarball: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/7a70d84bf39fe3f6366979540d7c186f8042dca8}
+  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/d0080152603e574343e115e2eef9aac500a5597e:
+    resolution: {gitHosted: true, integrity: sha512-ONcxwpDtVmS7c3iEBWDELHAt20UZWodPJvC4roogej1nu/fsxfF3IFPx1cGtwDchKDcqLzjH/4EfS2VVzH5Qjg==, tarball: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/d0080152603e574343e115e2eef9aac500a5597e}
     version: 1.2.7
     engines: {node: ^24.10.0}
 
@@ -3315,7 +3315,7 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/7a70d84bf39fe3f6366979540d7c186f8042dca8(typescript@6.0.3):
+  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/d0080152603e574343e115e2eef9aac500a5597e(typescript@6.0.3):
     dependencies:
       replace-in-file: 8.4.0
       semantic-release: 25.0.5(typescript@6.0.3)


### PR DESCRIPTION
## Summary
- update package.json with npm-check-updates patch and minor releases
- remove pnpm install state and regenerate pnpm-lock.yaml with pnpm update
- allow the test workflow to enable auto-merge after checks pass